### PR TITLE
Draft: Move back to llvm-sys for linking llvm

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  NYXSTONE_LLVM_PREFIX: "/usr/lib/llvm-15/"
+  LLVM_SYS_150_PREFIX: "/usr/lib/llvm-15/"
 
 jobs:
   linux:
@@ -46,9 +46,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX=$(brew --prefix llvm@15) cargo build
+      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" LLVM_SYS_150_PREFIX=$(brew --prefix llvm@15) cargo build
       working-directory: ${{ env.working-dir }}
     - name: Run tests
-      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" RUSTDOCFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX=$(brew --prefix llvm@15) cargo test
+      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" RUSTDOCFLAGS="-L$(brew --prefix zstd)/lib" LLVM_SYS_150_PREFIX=$(brew --prefix llvm@15) cargo test
       working-directory: ${{ env.working-dir }}
 

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["api-bindings", "compilers"]
 [dependencies]
 anyhow = { version = "1.0.68", default-features = true }
 cxx = "1.0.94"
+llvm-sys = { version = "150", features = ["prefer-static", "strict-versioning", "disable-alltargets-init"] }
 
 [build-dependencies]
 cxx-build = "1.0.94"

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -315,3 +315,8 @@ mod ffi {
 }
 
 unsafe impl Send for ffi::NyxstoneFFI {}
+
+// Unused call to llvm-sys to force linking with llvm.
+unsafe fn _force_llvm_sys_linkage() {
+    llvm_sys::target::LLVM_InitializeAllTargets();
+}


### PR DESCRIPTION
This MR re-introduces llvm-sys as the mechanism for linking llvm when using the rust bindings. The reason for this change is two-fold. First, the macos ci target is failing because of missing dependencies, I'm hoping that llvm-sys is better at handling those dependencies for mac. Second, it is really annoying to have to build llvm from scratch if only dynamic libraries are supplied by the package manager.

TODO:
- [ ] update documentation