### PR TITLE
Refactors the rust generics for label definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ use std::collections::HashMap;
 fn main() -> Result<()> {
     let nyxstone = Nyxstone::new("x86_64", NyxstoneConfig::default())?;
 
-    let bytes = nyxstone.assemble(
+    let bytes = nyxstone.assemble_with(
         "mov rax, rbx; cmp rax, rdx; jne .label",
         0x1000,
         &HashMap::from([(".label", 0x1200)]),

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -35,7 +35,16 @@ fn main() -> Result<()> {
     // Creating a nyxstone instance can fail, for example if the triple is invalid.
     let nyxstone = Nyxstone::new("x86_64", NyxstoneConfig::default())?;
 
-    let instructions = nyxstone.assemble_to_instructions(
+    // Assemble a single instruction
+    let instructions = nyxstone.assemble_to_instructions("xor rax, rax", 0x100)?;
+
+    println!("Assembled: ");
+    for instr in instructions {
+        println!("0x{:04x}: {:15} - {:02x?}", instr.address, instr.assembly, instr.bytes);
+    }
+
+    // Assemble with a label definition
+    let instructions = nyxstone.assemble_to_instructions_with(
         "mov rax, rbx; cmp rax, rdx; jne .label",
         0x100,
         &HashMap::from([(".label", 0x1200)]),

--- a/bindings/rust/examples/cli.rs
+++ b/bindings/rust/examples/cli.rs
@@ -75,14 +75,9 @@ fn main() -> Result<()> {
 
     match cli.command {
         Command::Assemble { labels, assembly } => {
-            let labels = labels.unwrap_or(vec![]);
+            let labels: HashMap<String, u64> = labels.map(|labels| labels.into_iter().collect()).unwrap_or_default();
 
-            let labels = labels
-                .iter()
-                .map(|(s, a)| (s.as_str(), *a))
-                .collect::<HashMap<&str, u64>>();
-
-            let instructions = nyxstone.assemble_to_instructions(&assembly, address, &labels)?;
+            let instructions = nyxstone.assemble_to_instructions_with(&assembly, address, &labels)?;
 
             print_instructions(&instructions);
         }

--- a/bindings/rust/examples/usage.rs
+++ b/bindings/rust/examples/usage.rs
@@ -10,7 +10,7 @@ fn main() -> Result<()> {
     // Creating a nyxstone instance can fail, for example if the triple is invalid.
     let nyxstone = Nyxstone::new("x86_64", NyxstoneConfig::default())?;
 
-    let instructions = nyxstone.assemble_to_instructions(
+    let instructions = nyxstone.assemble_to_instructions_with(
         "mov rax, rbx; cmp rax, rdx; jne .label",
         0x100,
         &HashMap::from([(".label", 0x1200)]),

--- a/bindings/rust/tests/validation.rs
+++ b/bindings/rust/tests/validation.rs
@@ -10,7 +10,7 @@ mod tests {
     fn assembler_test() -> Result<()> {
         let nyxstone = Nyxstone::new("x86_64-linux-gnu", NyxstoneConfig::default())?;
 
-        let result = nyxstone.assemble("mov rax, rax", 0x1000, &HashMap::with_capacity(0))?;
+        let result = nyxstone.assemble("mov rax, rax", 0x1000)?;
         assert_eq!(result, vec![0x48, 0x89, 0xc0]);
 
         Ok(())
@@ -30,7 +30,7 @@ mod tests {
     fn empty_input() -> Result<()> {
         let nyxstone = Nyxstone::new("x86_64-linux-gnu", NyxstoneConfig::default())?;
 
-        let result = nyxstone.assemble("", 0x0, &HashMap::new())?;
+        let result = nyxstone.assemble("", 0x0)?;
         assert!(result.is_empty());
 
         let result = nyxstone.disassemble(&[], 0x0, 0)?;
@@ -44,26 +44,26 @@ mod tests {
         let nyxstone = Nyxstone::new("armv6m-none-eabi", NyxstoneConfig::default())?;
 
         // 4 byte aligned instruction addresses
-        let bytes = nyxstone.assemble("ldr r0, .label", 0x00, &HashMap::from([(".label", 0x04)]))?;
+        let bytes = nyxstone.assemble_with("ldr r0, .label", 0x00, &HashMap::from([(".label", 0x04)]))?;
         assert_eq!(bytes, vec![0x00, 0x48]);
 
-        let bytes = nyxstone.assemble("ldr r0, .label", 0x00, &HashMap::from([(".label", 0x08)]))?;
+        let bytes = nyxstone.assemble_with("ldr r0, .label", 0x00, &HashMap::from([(".label", 0x08)]))?;
         assert_eq!(bytes, vec![0x01, 0x48]);
 
-        let bytes = nyxstone.assemble("ldr r0, .label", 0x00, &HashMap::from([(".label", 0x0c)]))?;
+        let bytes = nyxstone.assemble_with("ldr r0, .label", 0x00, &HashMap::from([(".label", 0x0c)]))?;
         assert_eq!(bytes, vec![0x02, 0x48]);
 
         // 2 byte aligned instruction addresses
-        let bytes = nyxstone.assemble("ldr r0, .label", 0x02, &HashMap::from([(".label", 0x04)]))?;
+        let bytes = nyxstone.assemble_with("ldr r0, .label", 0x02, &HashMap::from([(".label", 0x04)]))?;
         assert_eq!(bytes, vec![0x00, 0x48]);
 
-        let bytes = nyxstone.assemble("ldr r0, .label", 0x02, &HashMap::from([(".label", 0x08)]))?;
+        let bytes = nyxstone.assemble_with("ldr r0, .label", 0x02, &HashMap::from([(".label", 0x08)]))?;
         assert_eq!(bytes, vec![0x01, 0x48]);
 
-        let bytes = nyxstone.assemble("ldr r0, .label", 0x02, &HashMap::from([(".label", 0x0c)]))?;
+        let bytes = nyxstone.assemble_with("ldr r0, .label", 0x02, &HashMap::from([(".label", 0x0c)]))?;
         assert_eq!(bytes, vec![0x02, 0x48]);
 
-        let bytes = nyxstone.assemble(
+        let bytes = nyxstone.assemble_with(
             "ldr r0, .label\nldr r0, .label",
             0x02,
             &HashMap::from([(".label", 0x0c)]),
@@ -71,7 +71,7 @@ mod tests {
         assert_eq!(bytes, vec![0x02, 0x48, 0x01, 0x48]);
 
         // this should fail because the label target address for ldr instruction is not 4 byte aligned!
-        let bytes = nyxstone.assemble("ldr r0, .label", 0x0a, &HashMap::from([(".label", 0x0e)]));
+        let bytes = nyxstone.assemble_with("ldr r0, .label", 0x0a, &HashMap::from([(".label", 0x0e)]));
         assert!(bytes.is_err());
 
         Ok(())
@@ -82,7 +82,7 @@ mod tests {
         let nyxstone_armv8m = Nyxstone::new("armv8m.main-none-eabi", NyxstoneConfig::default())?;
 
         // #8  assembly="ldr r3, .lbl_0x00c0f4\n.lbl_0x00c0f4:\n", address=49352,
-        let result = nyxstone_armv8m.assemble(
+        let result = nyxstone_armv8m.assemble_with(
             "ldr r3, .lbl_0x00c0f4",
             0xC0C8,
             &HashMap::from([(".lbl_0x00c0f4", 0xc0f4)]),
@@ -90,7 +90,7 @@ mod tests {
 
         assert_eq!(result, vec![0x0a, 0x4b]);
 
-        let result = nyxstone_armv8m.assemble("ldr r3, .label", 0, &HashMap::from([(".label", 4000)]))?;
+        let result = nyxstone_armv8m.assemble_with("ldr r3, .label", 0, &HashMap::from([(".label", 4000)]))?;
 
         assert_eq!(result, vec![0xDF, 0xF8, 0x9C, 0x3F]);
 
@@ -104,13 +104,13 @@ mod tests {
 
         let labels = HashMap::from([(".label", 0x1010)]);
 
-        let result = nyxstone_x86_64.assemble("mov rax, rax", 0x1000, &labels)?;
+        let result = nyxstone_x86_64.assemble_with("mov rax, rax", 0x1000, &labels)?;
         assert_eq!(result, vec![0x48, 0x89, 0xc0]);
 
-        let result = nyxstone_armv8m.assemble("bne .label", 0x1000, &labels)?;
+        let result = nyxstone_armv8m.assemble_with("bne .label", 0x1000, &labels)?;
         assert_eq!(result, vec![0x06, 0xd1]);
 
-        let result = nyxstone_x86_64.assemble_to_instructions("mov rax, rax", 0x1000, &labels)?;
+        let result = nyxstone_x86_64.assemble_to_instructions_with("mov rax, rax", 0x1000, &labels)?;
         assert_eq!(
             result,
             vec![Instruction {
@@ -120,7 +120,7 @@ mod tests {
             }]
         );
 
-        let result = nyxstone_armv8m.assemble_to_instructions("bne .label", 0x1000, &labels)?;
+        let result = nyxstone_armv8m.assemble_to_instructions_with("bne .label", 0x1000, &labels)?;
 
         assert_eq!(
             result,
@@ -160,10 +160,14 @@ mod tests {
     fn nyxstone_armv8a_ldr_regression_test() -> Result<()> {
         let nyxstone_armv8a = Nyxstone::new("aarch64-linux-gnueabihf", NyxstoneConfig::default())?;
 
-        let result = nyxstone_armv8a.assemble("ldr x10, .label", 0x0, &HashMap::from([(".label", 4000)]))?;
+        let result = nyxstone_armv8a.assemble_with("ldr x10, .label", 0x0, &HashMap::from([(".label", 4000)]))?;
         assert_eq!(result, vec![0x0A, 0x7D, 0x00, 0x58]);
 
-        let _ = nyxstone_armv8a.assemble_to_instructions("ldr x10, .label", 0x0, &HashMap::from([(".label", 4000)]))?;
+        let _ = nyxstone_armv8a.assemble_to_instructions_with(
+            "ldr x10, .label",
+            0x0,
+            &HashMap::from([(".label", 4000)]),
+        )?;
 
         Ok(())
     }
@@ -172,7 +176,7 @@ mod tests {
     fn nyxstone_armv8m_ldr_regression_test() -> Result<()> {
         let nyxstone_armv8m = Nyxstone::new("armv8m.main-none-eabi", NyxstoneConfig::default())?;
 
-        let result = nyxstone_armv8m.assemble("ldr r3, .label", 0x0, &HashMap::from([(".label", 4000)]))?;
+        let result = nyxstone_armv8m.assemble_with("ldr r3, .label", 0x0, &HashMap::from([(".label", 4000)]))?;
         assert_eq!(result, vec![0xdf, 0xf8, 0x9c, 0x3f]);
 
         Ok(())
@@ -185,12 +189,12 @@ mod tests {
         let labels = HashMap::from([(".label", 0x1010)]);
 
         // test adr/adrp instructions
-        let result = nyxstone_armv8a.assemble("adr x0, .label", 0x1000, &labels)?;
+        let result = nyxstone_armv8a.assemble_with("adr x0, .label", 0x1000, &labels)?;
         // 0x0000000000001000:  80 00 00 10    adr x0, #0x1010
         // because pc + offset = 0x1000 + 0x10 = 0x1010
         assert_eq!(result, vec![0x80, 0x00, 0x00, 0x10], "assemble");
 
-        let result = nyxstone_armv8a.assemble_to_instructions("adr x0, .label", 0x1000, &labels)?;
+        let result = nyxstone_armv8a.assemble_to_instructions_with("adr x0, .label", 0x1000, &labels)?;
         assert_eq!(result.len(), 1);
         assert_eq!(
             result[0].bytes,
@@ -198,13 +202,13 @@ mod tests {
             "assemble_to_instructions"
         );
 
-        let result = nyxstone_armv8a.assemble("adrp x3, .label", 0x1000, &HashMap::from([(".label", 0x3000)]))?;
+        let result = nyxstone_armv8a.assemble_with("adrp x3, .label", 0x1000, &HashMap::from([(".label", 0x3000)]))?;
         assert_eq!(result, vec![0x03, 0x00, 0x00, 0xd0], "assemble");
 
-        let result = nyxstone_armv8a.assemble("adrp x3, .label", 0x3000, &HashMap::from([(".label", 0x1000)]))?;
+        let result = nyxstone_armv8a.assemble_with("adrp x3, .label", 0x3000, &HashMap::from([(".label", 0x1000)]))?;
         assert_eq!(result, vec![0xe3, 0xff, 0xff, 0xd0], "assemble");
 
-        let result = nyxstone_armv8a.assemble_to_instructions(
+        let result = nyxstone_armv8a.assemble_to_instructions_with(
             "adrp x3, .label",
             0x1000,
             &HashMap::from([(".label", 0x3000)]),
@@ -216,10 +220,10 @@ mod tests {
             "assemble_to_instructions"
         );
 
-        let result = nyxstone_armv8a.assemble("adrp x30, .label", 0x1000, &HashMap::from([(".label", 0x2000)]))?;
+        let result = nyxstone_armv8a.assemble_with("adrp x30, .label", 0x1000, &HashMap::from([(".label", 0x2000)]))?;
         assert_eq!(result, vec![0x1e, 0x00, 0x00, 0xb0], "assemble");
 
-        let result = nyxstone_armv8a.assemble("adrp x15, .label", 0x1000, &HashMap::from([(".label", 0x1010)]))?;
+        let result = nyxstone_armv8a.assemble_with("adrp x15, .label", 0x1000, &HashMap::from([(".label", 0x1010)]))?;
         assert_eq!(result, vec![0x0F, 0x00, 0x00, 0xb0], "assemble");
 
         Ok(())
@@ -232,10 +236,10 @@ mod tests {
 
         let labels = HashMap::from([(".label", 0x1010)]);
 
-        let result = nyxstone_armv8m.assemble("bl .label", 0x1000, &labels)?;
+        let result = nyxstone_armv8m.assemble_with("bl .label", 0x1000, &labels)?;
         assert_eq!(result, vec![0x00, 0xf0, 0x06, 0xf8], "assemble");
 
-        let result = nyxstone_armv8m.assemble_to_instructions("bl .label", 0x1000, &labels)?;
+        let result = nyxstone_armv8m.assemble_to_instructions_with("bl .label", 0x1000, &labels)?;
         assert_eq!(result.len(), 1);
         assert_eq!(
             result[0].bytes,
@@ -243,10 +247,10 @@ mod tests {
             "assemble_to_instructions"
         );
 
-        let result = nyxstone_x86_64.assemble("call .label", 0x1000, &labels)?;
+        let result = nyxstone_x86_64.assemble_with("call .label", 0x1000, &labels)?;
         assert_eq!(result, vec![0xe8, 0x0b, 0x00, 0x00, 0x00], "assemble");
 
-        let result = nyxstone_x86_64.assemble_to_instructions("call .label", 0x1000, &labels)?;
+        let result = nyxstone_x86_64.assemble_to_instructions_with("call .label", 0x1000, &labels)?;
         assert_eq!(result.len(), 1);
         assert_eq!(
             result[0].bytes,
@@ -264,16 +268,16 @@ mod tests {
         let labels = HashMap::from([(".label", 0x1010)]);
 
         // test adr/adrp instructions
-        let result = nyxstone_armv8m.assemble("adr r0, .label", 0x1000, &labels)?;
+        let result = nyxstone_armv8m.assemble_with("adr r0, .label", 0x1000, &labels)?;
         // 0x0000000000001000:  80 00 00 10    adr x0, #0x1010
         // because pc + offset = 0x1000 + 0x10 = 0x1010
         assert_eq!(result, vec![0x03, 0xa0], "assemble");
 
-        let result = nyxstone_armv8m.assemble_to_instructions("adr r0, .label", 0x1000, &labels)?;
+        let result = nyxstone_armv8m.assemble_to_instructions_with("adr r0, .label", 0x1000, &labels)?;
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].bytes, vec![0x03, 0xa0], "assemble_to_instructions");
 
-        let result = nyxstone_armv8m.assemble_to_instructions("adr r0, .label", 0x1020, &labels)?;
+        let result = nyxstone_armv8m.assemble_to_instructions_with("adr r0, .label", 0x1020, &labels)?;
         assert_eq!(result.len(), 1);
         assert_eq!(
             result[0].bytes,
@@ -293,7 +297,7 @@ mod tests {
         let nyxstone_armv8m = Nyxstone::new("armv8m.main-none-eabi", config)?;
 
         // test floating point instructions
-        let bytes = nyxstone_armv8m.assemble("vadd.f16 s0, s1, s2", 0x1000, &HashMap::with_capacity(0))?;
+        let bytes = nyxstone_armv8m.assemble("vadd.f16 s0, s1, s2", 0x1000)?;
         assert_eq!(bytes, vec![0x30, 0xee, 0x81, 0x09]);
 
         let instructions = nyxstone_armv8m.disassemble_to_instructions(&bytes, 0x1000, 0)?;
@@ -331,7 +335,7 @@ mod tests {
         let nyxstone_armv8m = Nyxstone::new("armv8m.main-none-eabi", config)?;
 
         // Test that floating point instructions fail if the feature is not enabled.
-        let result = nyxstone_armv8m.assemble("vadd.f16 s0, s1, s2", 0x1000, &HashMap::with_capacity(0));
+        let result = nyxstone_armv8m.assemble("vadd.f16 s0, s1, s2", 0x1000);
         assert!(result.is_err());
 
         let result = nyxstone_armv8m.disassemble(&[0x30, 0xee, 0x81, 0x09], 0x1000, 0);
@@ -380,7 +384,7 @@ mod tests {
     fn armv8a_adr_out_of_range_regression() -> Result<()> {
         let nyxstone_armv8a = Nyxstone::new("aarch64-linux-gnueabihf", NyxstoneConfig::default())?;
 
-        let result = nyxstone_armv8a.assemble("adr x21, .label", 0x0, &HashMap::from([(".label", 0x100000)]));
+        let result = nyxstone_armv8a.assemble_with("adr x21, .label", 0x0, &HashMap::from([(".label", 0x100000)]));
 
         assert!(result.is_err());
 
@@ -391,7 +395,7 @@ mod tests {
     fn armv8m_adr_out_of_range_regression() -> Result<()> {
         let nyxstone_armv8m = Nyxstone::new("armv8m.main-none-eabi", NyxstoneConfig::default())?;
 
-        let result = nyxstone_armv8m.assemble("adr r0, .label", 0x0, &HashMap::from([(".label", 0x1010)]));
+        let result = nyxstone_armv8m.assemble_with("adr r0, .label", 0x0, &HashMap::from([(".label", 0x1010)]));
 
         assert!(result.is_err());
 
@@ -476,7 +480,7 @@ mod tests {
 
                             label.insert(".label", (start_address as i64 + offset).try_into()?);
 
-                            let result = nyxstone.assemble(instruction, address, &label);
+                            let result = nyxstone.assemble_with(instruction, address, &label);
 
                             let is_not_aligned = offset % align.unwrap_or(offset) != 0;
 


### PR DESCRIPTION
Previously, the generics for label definitions enforced that the passed container is `IntoIterator<Item = (&&str, &u64)>`. As a consequence, the container was unable to own the label names and could only hold a `&str`. When implementing the rust cli example, we noticed that this really impractical, since it forces the caller to hold two containers, one which owns the label names as `String`s and one which can be passed to the functions, holding the `&str` references to the first container.

This commit tries to make the generics more practical by only requiring the label name to implement `AsRef<str>`. This change allows the passed container to own the label names as `String`s.

One downside of this change is that whenever no labels need to be passed, the caller needs to specify the exact types in the container, like this:
```rust
nyxstone.assemble("xor rax,rax", 0, &HashMap::<&str, u64>::new())
```
To keep the API ergonomic, this commit moves the assemble functions to `assemble_with` functions, and replaces the original functions so that they no longer take a map of labels. This way the caller can simply call `assemble` if they do not need to provide labels instead of specifying the exact type of the map container every time.

Closes #48.