### PR TITLE
Allow all LLVM versions >= 15 and support dynamic linking

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  NYXSTONE_LLVM_PREFIX: "/usr/lib/llvm-15/"
 
 jobs:
   linux:
@@ -16,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Packages
-      run: sudo apt-get install llvm-15 llvm-15-dev zlib1g-dev libzstd-dev libboost-program-options-dev cppcheck clang-tidy clang-format
+      run: sudo apt-get install zlib1g-dev libzstd-dev libboost-program-options-dev cppcheck clang-tidy clang-format
     - name: Code quality - fmt
       run: ./tool/format.sh check 
     - name: Code quality - cppcheck

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       NYXSTONE_LLVM_PREFIX: "/usr/lib/llvm-15/"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Packages
       run: |
         sudo apt-get update
@@ -44,7 +44,7 @@ jobs:
   mac-llvm-15:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Packages
       run: brew install llvm@15
     - name: Build
@@ -65,7 +65,7 @@ jobs:
   mac-llvm-16:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Packages
       run: brew install llvm@16
     - name: Build
@@ -86,7 +86,7 @@ jobs:
   mac-llvm-17:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Packages
       run: brew install llvm@17
     - name: Build
@@ -107,7 +107,7 @@ jobs:
   mac-llvm-18:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Packages
       run: brew install llvm@18
     - name: Build

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -10,26 +10,117 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  linux:
+  linux-llvm-15:
     runs-on: ubuntu-latest
+    env:
+      NYXSTONE_LLVM_PREFIX: "/usr/lib/llvm-15/"
     steps:
     - uses: actions/checkout@v3
     - name: Packages
-      run: sudo apt-get install zlib1g-dev libzstd-dev libboost-program-options-dev cppcheck clang-tidy clang-format
+      run: |
+        sudo apt-get update
+        sudo apt-get install zlib1g-dev libzstd-dev cppcheck clang-tidy clang-format llvm-15 llvm-15-dev
     - name: Code quality - fmt
-      run: ./tool/format.sh check 
+      run: ./tool/format.sh check
     - name: Code quality - cppcheck
       run: ./tool/static-analysis-cppcheck.sh
     - name: Code quality - clang-tidy
       run: ./tool/static-analysis-tidy.sh
     - name: Build
-      run: mkdir build/ && cd build && cmake .. && make
-    - name: Test
-      run: make test
-      working-directory: build/
-    - name: cli
       run: |
-        ./nyxstone "mov rax, rbx" &&
+        mkdir build
+        cd build
+        cmake ..
+        make
+    - name: Test
+      working-directory: build/
+      run: make test
+    - name: cli
+      working-directory: build/
+      run: |
+        ./nyxstone "mov rax, rbx"
         ./nyxstone "jmp label" --labels "label=0x1000"
 
+  mac-llvm-15:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Packages
+      run: brew install llvm@15
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@15)" cmake ..
+        make
+    - name: Test
       working-directory: build/
+      run: make test
+    - name: cli
+      working-directory: build/
+      run: |
+        ./nyxstone "mov rax, rbx"
+        ./nyxstone "jmp label" --labels "label=0x1000"
+
+  mac-llvm-16:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Packages
+      run: brew install llvm@16
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@16)" cmake ..
+        make
+    - name: Test
+      working-directory: build/
+      run: make test
+    - name: cli
+      working-directory: build/
+      run: |
+        ./nyxstone "mov rax, rbx"
+        ./nyxstone "jmp label" --labels "label=0x1000"
+
+  mac-llvm-17:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Packages
+      run: brew install llvm@17
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@17)" cmake ..
+        make
+    - name: Test
+      working-directory: build/
+      run: make test
+    - name: cli
+      working-directory: build/
+      run: |
+        ./nyxstone "mov rax, rbx"
+        ./nyxstone "jmp label" --labels "label=0x1000"
+
+  mac-llvm-18:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Packages
+      run: brew install llvm@18
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@18)" cmake ..
+        make
+    - name: Test
+      working-directory: build/
+      run: make test
+    - name: cli
+      working-directory: build/
+      run: |
+        ./nyxstone "mov rax, rbx"
+        ./nyxstone "jmp label" --labels "label=0x1000"

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Packages
       run: sudo apt-get install -y doxygen graphviz

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-env:
-  NYXSTONE_LLVM_PREFIX: "/usr/lib/llvm-15/"
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Packages
-      run: sudo apt-get install llvm-15 llvm-15-dev zlib1g-dev libzstd-dev
+      run: sudo apt-get install zlib1g-dev libzstd-dev
     - name: Build
       run: pip install .
       working-directory: ${{ env.working-dir }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,11 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       working-dir: ./bindings/python
+      NYXSTONE_LLVM_PREFIX: "/usr/lib/llvm-15/"
 
     steps:
     - uses: actions/checkout@v3
     - name: Packages
-      run: sudo apt-get install zlib1g-dev libzstd-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install zlib1g-dev libzstd-dev llvm-15 llvm-15-dev
     - name: Build
       run: pip install .
       working-directory: ${{ env.working-dir }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,7 +14,7 @@ jobs:
       NYXSTONE_LLVM_PREFIX: "/usr/lib/llvm-15/"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Packages
       run: |
         sudo apt-get update

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,8 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  NYXSTONE_LLVM_PREFIX: "/usr/lib/llvm-15/"
-  NYXSTONE_LINK_FFI: "1"
 
 jobs:
   linux:
@@ -19,9 +17,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Packages
-      run: sudo apt-get install llvm-15 llvm-15-dev zlib1g-dev libzstd-dev
+      run: sudo apt-get install zlib1g-dev libzstd-dev
     - name: Code quality
-      run: cargo fmt --all -- --check && cargo clippy -- -D warnings
+      run: |
+        cargo fmt --all -- --check
+        cargo clippy -- -D warnings
       working-directory: ${{ env.working-dir }}
     - name: Build
       run: cargo build
@@ -36,10 +36,12 @@ jobs:
       working-dir: ./bindings/rust
     steps:
     - uses: actions/checkout@v3
+    - name: Packages
+      run: brew install llvm@18
     - name: Build
-      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX=$(brew --prefix llvm@15) cargo build
+      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@18)" NYXSTONE_LINK_FFI=1 cargo build
       working-directory: ${{ env.working-dir }}
     - name: Run tests
-      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" RUSTDOCFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX=$(brew --prefix llvm@15) cargo test
+      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" RUSTDOCFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@18)" NYXSTONE_LINK_FFI=1 cargo test
       working-directory: ${{ env.working-dir }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   NYXSTONE_LLVM_PREFIX: "/usr/lib/llvm-15/"
+  NYXSTONE_LINK_FFI: "1"
 
 jobs:
   linux:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,14 +10,18 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  linux:
+  linux-llvm-15:
     runs-on: ubuntu-latest
     env:
       working-dir: ./bindings/rust
+      NYXSTONE_LLVM_PREFIX: "/usr/lib/llvm-15/"
+      NYXSTONE_LINK_FFI: "1"
     steps:
     - uses: actions/checkout@v3
     - name: Packages
-      run: sudo apt-get install zlib1g-dev libzstd-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install llvm-15 llvm-15-dev zlib1g-dev libzstd-dev
     - name: Code quality
       run: |
         cargo fmt --all -- --check
@@ -30,7 +34,52 @@ jobs:
       run: cargo test
       working-directory: ${{ env.working-dir }}
 
-  mac:
+  mac-llvm-15:
+    runs-on: macos-latest
+    env:
+      working-dir: ./bindings/rust
+    steps:
+    - uses: actions/checkout@v3
+    - name: Packages
+      run: brew install llvm@15
+    - name: Build
+      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@15)" NYXSTONE_LINK_FFI=1 cargo build
+      working-directory: ${{ env.working-dir }}
+    - name: Run tests
+      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" RUSTDOCFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@15)" NYXSTONE_LINK_FFI=1 cargo test
+      working-directory: ${{ env.working-dir }}
+
+  mac-llvm-16:
+    runs-on: macos-latest
+    env:
+      working-dir: ./bindings/rust
+    steps:
+    - uses: actions/checkout@v3
+    - name: Packages
+      run: brew install llvm@16
+    - name: Build
+      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@16)" NYXSTONE_LINK_FFI=1 cargo build
+      working-directory: ${{ env.working-dir }}
+    - name: Run tests
+      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" RUSTDOCFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@16)" NYXSTONE_LINK_FFI=1 cargo test
+      working-directory: ${{ env.working-dir }}
+
+  mac-llvm-17:
+    runs-on: macos-latest
+    env:
+      working-dir: ./bindings/rust
+    steps:
+    - uses: actions/checkout@v3
+    - name: Packages
+      run: brew install llvm@17
+    - name: Build
+      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@17)" NYXSTONE_LINK_FFI=1 cargo build
+      working-directory: ${{ env.working-dir }}
+    - name: Run tests
+      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" RUSTDOCFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@17)" NYXSTONE_LINK_FFI=1 cargo test
+      working-directory: ${{ env.working-dir }}
+
+  mac-llvm-18:
     runs-on: macos-latest
     env:
       working-dir: ./bindings/rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
       NYXSTONE_LLVM_PREFIX: "/usr/lib/llvm-15/"
       NYXSTONE_LINK_FFI: "1"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Packages
       run: |
         sudo apt-get update
@@ -39,7 +39,7 @@ jobs:
     env:
       working-dir: ./bindings/rust
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Packages
       run: brew install llvm@15
     - name: Build
@@ -54,7 +54,7 @@ jobs:
     env:
       working-dir: ./bindings/rust
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Packages
       run: brew install llvm@16
     - name: Build
@@ -69,7 +69,7 @@ jobs:
     env:
       working-dir: ./bindings/rust
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Packages
       run: brew install llvm@17
     - name: Build
@@ -84,7 +84,7 @@ jobs:
     env:
       working-dir: ./bindings/rust
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Packages
       run: brew install llvm@18
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(DEFINED $ENV{NYXSTONE_LLVM_PREFIX})
     set(CMAKE_PREFIX_PATH $ENV{NYXSTONE_LLVM_PREFIX})
 endif()
 
-find_package(LLVM-Wrapper 15 REQUIRED COMPONENTS
+find_package(LLVM-Wrapper REQUIRED COMPONENTS
     core
     mc
     AllTargetsCodeGens

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,13 +19,13 @@ option(NYXSTONE_SANITIZERS "Enable sanitizers" OFF)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-if(DEFINED $ENV{NYXSTONE_LLVM_PREFIX})
+if(DEFINED ENV{NYXSTONE_LLVM_PREFIX})
     # Ignore LLVM_ROOT variables
     set(CMAKE_FIND_USE_PACKAGE_ROOT_PATH OFF)
     set(CMAKE_PREFIX_PATH $ENV{NYXSTONE_LLVM_PREFIX})
 endif()
 
-find_package(LLVM-Wrapper REQUIRED COMPONENTS
+find_package(LLVM-Wrapper COMPONENTS
     core
     mc
     AllTargetsCodeGens

--- a/README.md
+++ b/README.md
@@ -50,38 +50,46 @@ This section provides instructions on how to get started with Nyxstone, covering
 
 ### Prerequisites
 
-Before building Nyxstone, ensure clang and LLVM 15 are present on your system. Nyxstone looks for `llvm-config` in your system's `$PATH` or the specified environment variable `$NYXSTONE_LLVM_PREFIX/bin`.
+Before building Nyxstone, ensure clang and LLVM 18 are present on your system. Nyxstone looks for `llvm-config` in your system's `$PATH` or the specified environment variable `$NYXSTONE_LLVM_PREFIX/bin`.
 
-Installation Options for LLVM 15:
+Installation Options for LLVM 18:
 
-* Debian/Ubuntu
+* Ubuntu
 ```bash
-sudo apt install llvm-15 llvm-15-dev
-export NYXSTONE_LLVM_PREFIX=/usr/lib/llvm-15/
+sudo apt install llvm-18 llvm-18-dev
+```
+
+* Debian
+LLVM 18 is currently only available via the testing repositories.
+Refer to [https://apt.llvm.org/](https://apt.llvm.org/) for install instructions.
+
+* Arch
+```bash
+sudo pacman -S llvm llvm-libs
 ```
 
 * Homebrew (macOS, Linux and others):
 ```bash
-brew install llvm@15
-export NYXSTONE_LLVM_PREFIX=/opt/homebrew/opt/llvm@15
+brew install llvm@18
+export NYXSTONE_LLVM_PREFIX=/opt/homebrew/opt/llvm@18
 ```
 
 * From LLVM Source:
 
-_Note_: On Windows you need to run these commands from a Visual Studio 2022 x64 command prompt. Additionally replace `~lib/my-llvm-15` with a different path.
+_Note_: On Windows you need to run these commands from a Visual Studio 2022 x64 command prompt. Additionally replace `~lib/my-llvm-18` with a different path.
 
 ```bash
 # checkout llvm
-git clone -b release/15.x --single-branch https://github.com/llvm/llvm-project.git
+git clone -b release/18.x --single-branch https://github.com/llvm/llvm-project.git
 cd llvm-project
 
 # build LLVM with custom installation directory
 cmake -S llvm -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_PARALLEL_LINK_JOBS=1
 cmake --build build
-cmake --install build --prefix ~/lib/my-llvm-15
+cmake --install build --prefix ~/lib/my-llvm-18
 
 # export path
-export NYXSTONE_LLVM_PREFIX=~/lib/my-llvm-15
+export NYXSTONE_LLVM_PREFIX=~/lib/my-llvm-18
 ```
 
 Also make sure to install any system dependent libraries needed by your LLVM version for static linking. They can be viewed with the command `llvm-config --system-libs`; the list can be empty. On Ubuntu/Debian, you will need the packages `zlib1g-dev` and `zlibstd-dev`.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This section provides instructions on how to get started with Nyxstone, covering
 
 ### Prerequisites
 
-Before building Nyxstone, ensure clang and LLVM 15 are present as statically linked libraries. Nyxstone looks for `llvm-config` in your system's `$PATH` or the specified environment variable `$NYXSTONE_LLVM_PREFIX/bin`.
+Before building Nyxstone, ensure clang and LLVM 15 are present on your system. Nyxstone looks for `llvm-config` in your system's `$PATH` or the specified environment variable `$NYXSTONE_LLVM_PREFIX/bin`.
 
 Installation Options for LLVM 15:
 
@@ -320,3 +320,6 @@ The current contributors are:
 * Marc Fyrbiak (emproof)
 * Tim Blazytko (emproof)
 
+## Acknowledgements
+
+To ensure that we link LLVM correctly with proper versioning in Rust, we adapted the build.rs from [llvm-sys](https://gitlab.com/taricorp/llvm-sys.rs/).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Nyxstone is a powerful assembly and disassembly library based on LLVM. It doesnâ
 
 ## Core Features
 
-* Assembles and disassembles code for all architectures supported by LLVM 15, including x86, ARM, MIPS, RISC-V and others.
+* Assembles and disassembles code for all architectures supported by the linked LLVM, including x86, ARM, MIPS, RISC-V and others.
 
 * C++ library based on LLVM with Rust and Python bindings.
 
@@ -50,18 +50,18 @@ This section provides instructions on how to get started with Nyxstone, covering
 
 ### Prerequisites
 
-Before building Nyxstone, ensure clang and LLVM 18 are present on your system. Nyxstone looks for `llvm-config` in your system's `$PATH` or the specified environment variable `$NYXSTONE_LLVM_PREFIX/bin`.
+Before building Nyxstone, ensure clang and LLVM (version >= 15) are present on your system. Nyxstone looks for `llvm-config` in your system's `$PATH` or the specified environment variable `$NYXSTONE_LLVM_PREFIX/bin`.
 
-Installation Options for LLVM 18:
+Installation Options for LLVM versions 15-18:
 
 * Ubuntu
 ```bash
-sudo apt install llvm-18 llvm-18-dev
+sudo apt install llvm-${version} llvm-${version}-dev
 ```
 
 * Debian
-LLVM 18 is currently only available via the testing repositories.
-Refer to [https://apt.llvm.org/](https://apt.llvm.org/) for install instructions.
+LLVM version 15 and 16 are available through debian repositories. Installation is the same as for Ubuntu.
+For versions 17 or 18 refer to [https://apt.llvm.org/](https://apt.llvm.org/) for installation instructions.
 
 * Arch
 ```bash

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ This section provides instructions on how to get started with Nyxstone, covering
 
 ### Prerequisites
 
-Before building Nyxstone, ensure clang and LLVM (version >= 15) are present on your system. Nyxstone looks for `llvm-config` in your system's `$PATH` or the specified environment variable `$NYXSTONE_LLVM_PREFIX/bin`.
+Before building Nyxstone, ensure clang and LLVM are present on your system. Nyxstone supports LLVM major versions 15-18.
+When building it looks for `llvm-config` in your system's `$PATH` or the specified environment variable `$NYXSTONE_LLVM_PREFIX/bin`.
 
 Installation Options for LLVM versions 15-18:
 
@@ -176,7 +177,7 @@ $ ./nyxstone -p "0x1000" -l ".label=0x1238" "jmp .label"
 
 ### C++ Library
 
-To use Nyxstone as a C++ library, your C++ code has to be linked against Nyxstone and LLVM 15. 
+To use Nyxstone as a C++ library, your C++ code has to be linked against Nyxstone and LLVM.
 
 The following cmake example assumes Nyxstone in a subdirectory `nyxstone` in your project:
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -5,7 +5,7 @@
 
 ## Installation
 
-You need to have LLVM 15 installed to build the nyxstone bindings. The `setup.py` searches for LLVM in the `PATH` or in the directory set in the environment variable `NYXSTONE_LLVM_PREFIX`. Specifically, it searches for the binary `$NYXSTONE_LLVM_PREFIX/bin/llvm-config` and uses it to set the required libraries and cpp flags.
+You need to have LLVM 18 installed to build the nyxstone bindings. The `setup.py` searches for LLVM in the `PATH` or in the directory set in the environment variable `NYXSTONE_LLVM_PREFIX`. Specifically, it searches for the binary `$NYXSTONE_LLVM_PREFIX/bin/llvm-config` and uses it to set the required libraries and cpp flags.
 
 Running
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -5,7 +5,7 @@
 
 ## Installation
 
-You need to have LLVM 15 (with static library support) installed to build the nyxstone bindings. The `setup.py` searches for LLVM in the `PATH` or in the directory set in the environment variable `NYXSTONE_LLVM_PREFIX`. Specifically, it searches for the binary `$NYXSTONE_LLVM_PREFIX/bin/llvm-config` and uses it to set the required libraries and cpp flags.
+You need to have LLVM 15 installed to build the nyxstone bindings. The `setup.py` searches for LLVM in the `PATH` or in the directory set in the environment variable `NYXSTONE_LLVM_PREFIX`. Specifically, it searches for the binary `$NYXSTONE_LLVM_PREFIX/bin/llvm-config` and uses it to set the required libraries and cpp flags.
 
 Running
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -5,7 +5,7 @@
 
 ## Installation
 
-You need to have LLVM 18 installed to build the nyxstone bindings. The `setup.py` searches for LLVM in the `PATH` or in the directory set in the environment variable `NYXSTONE_LLVM_PREFIX`. Specifically, it searches for the binary `$NYXSTONE_LLVM_PREFIX/bin/llvm-config` and uses it to set the required libraries and cpp flags.
+You need to have LLVM (with at least version 15) installed to build the nyxstone bindings. The `setup.py` searches for LLVM in the `PATH` or in the directory set in the environment variable `NYXSTONE_LLVM_PREFIX`. Specifically, it searches for the binary `$NYXSTONE_LLVM_PREFIX/bin/llvm-config` and uses it to set the required libraries and cpp flags.
 
 Running
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -5,7 +5,7 @@
 
 ## Installation
 
-You need to have LLVM (with at least version 15) installed to build the nyxstone bindings. The `setup.py` searches for LLVM in the `PATH` or in the directory set in the environment variable `NYXSTONE_LLVM_PREFIX`. Specifically, it searches for the binary `$NYXSTONE_LLVM_PREFIX/bin/llvm-config` and uses it to set the required libraries and cpp flags.
+You need to have LLVM (with major version in the range 15-18) installed to build the nyxstone bindings. The `setup.py` searches for LLVM in the `PATH` or in the directory set in the environment variable `NYXSTONE_LLVM_PREFIX`. Specifically, it searches for the binary `$NYXSTONE_LLVM_PREFIX/bin/llvm-config` and uses it to set the required libraries and cpp flags.
 
 Running
 

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -35,6 +35,8 @@ class ValidLLVMConfig:
             )
             exit(1)
 
+        # check if we need to link dynamically
+        self.link_dynamic = False
         lib_output = subprocess.run(
             [
                 llvm_config,
@@ -42,13 +44,12 @@ class ValidLLVMConfig:
                 "--libs",
             ],
             capture_output=True,
+            check=False,
         )
 
         if lib_output.returncode != 0:
-            print(
-                "Cannot link statically, please install LLVM with static linking support"
-            )
-            exit(1)
+            print("No static libs found, linking dynamically")
+            self.link_dynamic = True
 
         self.config = llvm_config
 
@@ -56,7 +57,7 @@ class ValidLLVMConfig:
         lib_output = subprocess.run(
             [
                 self.config,
-                "--link-static",
+                "--link-static" if not self.link_dynamic else "--link-shared",
                 "--system-libs",
                 "--libs",
                 "core",

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -27,11 +27,11 @@ class ValidLLVMConfig:
             print(f"Could not find llvm-config in ${LLVM_PREFIX_NAME} or $PATH")
             exit(1)
 
-        major_version = version.split(".")[0]
+        major_version = int(version.split(".")[0])
 
-        if major_version != "18":
+        if major_version < 15:
             print(
-                f"LLVM Major version must be 18, found {major_version}! Try setting the env variable ${LLVM_PREFIX_NAME} to tell nyxstone about the install location of LLVM 18."
+                f"LLVM Major version must be at least 15, found {major_version}! Set the environment variable ${LLVM_PREFIX_NAME} to tell nyxstone about the install location of LLVM."
             )
             exit(1)
 

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -29,14 +29,15 @@ class ValidLLVMConfig:
 
         major_version = version.split(".")[0]
 
-        if major_version != "15":
+        if major_version != "18":
             print(
-                f"LLVM Major version must be 15, found {major_version}! Try setting the env variable ${LLVM_PREFIX_NAME} to tell nyxstone about the install location of LLVM 15."
+                f"LLVM Major version must be 18, found {major_version}! Try setting the env variable ${LLVM_PREFIX_NAME} to tell nyxstone about the install location of LLVM 18."
             )
             exit(1)
 
         # check if we need to link dynamically
         self.link_dynamic = False
+
         lib_output = subprocess.run(
             [
                 llvm_config,
@@ -78,6 +79,7 @@ class ValidLLVMConfig:
         lib_location = (
             subprocess.run([self.config, "--ldflags"], capture_output=True)
             .stdout.decode("utf-8")
+            .split(" ")[0]
             .replace("\n", "")  # remove trailing '\n'
             .replace("-L", "")  # remove leading -L re-added by pybind
             .strip()  # strip trailing whitespace
@@ -115,10 +117,7 @@ ext_modules = [
         include_dirs=["nyxstone-cpp/include/", "nyxstone-cpp/vendor", "nyxstone-cpp/src/", llvm_inc_dir],
         libraries=llvm_libs,
         library_dirs=[llvm_lib_dir],
-        extra_link_args=[
-            "-static-libstdc++",
-            "-static-libgcc",
-        ],  # try to reduce dependencies
+        extra_link_args=[],
     )
 ]
 

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -29,9 +29,9 @@ class ValidLLVMConfig:
 
         major_version = int(version.split(".")[0])
 
-        if major_version < 15:
+        if major_version < 15 or major_version > 18:
             print(
-                f"LLVM Major version must be at least 15, found {major_version}! Set the environment variable ${LLVM_PREFIX_NAME} to tell nyxstone about the install location of LLVM."
+                f"LLVM Major version must be in the range 15-18, found {major_version}! Set the environment variable ${LLVM_PREFIX_NAME} to tell nyxstone about the install location of LLVM."
             )
             exit(1)
 

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -7,7 +7,7 @@ Official bindings for the Nyxstone assembler/disassembler engine.
 
 ## Building
 
-The project can be build via `cargo build`, as long as LLVM 15 supporting static linking is installed in the `$PATH` or the environment variable `$NYXSTONE_LLVM_PREFIX` points to the installation location of such a LLVM 15 library. For further information conduct the Nyxstone README.md. The bindings further expect that the Nyxstone library is installed in the nyxstone sub-directory. This can be accomplished by using the Makefile target `nyxstone`.
+The project can be build via `cargo build`, as long as LLVM 18 is installed in the `$PATH` or the environment variable `$NYXSTONE_LLVM_PREFIX` points to the installation location of a LLVM 18 library.
 
 LLVM might be linked against FFI, but not correctly report this fact via `llvm-config`. If your LLVM does link FFI and
 Nyxstone fails to run, set the `NYXSTONE_LINK_FFI` environment variable to some value, which will ensure that Nyxstone
@@ -18,7 +18,7 @@ links `libffi`.
 Add nyxstone as a dependency in your `Cargo.toml`:
 ```
 [dependencies]
-nyxstone = "0.0.1"
+nyxstone = "0.1"
 ```
 
 Building nyxstone requires a C/C++ compiler to be installed on your system. Furthermore, Nyxstone requires LLVM 15 to be installed. Refer to the Building section for more information about setting the install location of LLVM.

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -9,6 +9,10 @@ Official bindings for the Nyxstone assembler/disassembler engine.
 
 The project can be build via `cargo build`, as long as LLVM 15 supporting static linking is installed in the `$PATH` or the environment variable `$NYXSTONE_LLVM_PREFIX` points to the installation location of such a LLVM 15 library. For further information conduct the Nyxstone README.md. The bindings further expect that the Nyxstone library is installed in the nyxstone sub-directory. This can be accomplished by using the Makefile target `nyxstone`.
 
+LLVM might be linked against FFI, but not correctly report this fact via `llvm-config`. If your LLVM does link FFI and
+Nyxstone fails to run, set the `NYXSTONE_LINK_FFI` environment variable to some value, which will ensure that Nyxstone
+links `libffi`.
+
 ## Installation
 
 Add nyxstone as a dependency in your `Cargo.toml`:

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -7,11 +7,11 @@ Official bindings for the Nyxstone assembler/disassembler engine.
 
 ## Building
 
-The project can be build via `cargo build`, as long as LLVM (with at least version 15) is installed in the `$PATH` or the environment variable `$NYXSTONE_LLVM_PREFIX` points to the installation location of a LLVM library.
+The project can be build via `cargo build`, as long as LLVM with a major version in the range 15-18 is installed in the `$PATH` or the environment variable `$NYXSTONE_LLVM_PREFIX` points to the installation location of a LLVM library.
 
 LLVM might be linked against FFI, but not correctly report this fact via `llvm-config`. If your LLVM does link FFI and
-Nyxstone fails to run, set the `NYXSTONE_LINK_FFI` environment variable to some value, which will ensure that Nyxstone
-links `libffi`.
+Nyxstone fails to run, set the `NYXSTONE_LINK_FFI` environment variable to `1`, which will ensure that Nyxstone
+links against `libffi`.
 
 ## Installation
 
@@ -21,7 +21,8 @@ Add nyxstone as a dependency in your `Cargo.toml`:
 nyxstone = "0.1"
 ```
 
-Building nyxstone requires a C/C++ compiler to be installed on your system. Furthermore, Nyxstone requires LLVM 15 to be installed. Refer to the Building section for more information about setting the install location of LLVM.
+Building nyxstone requires a C/C++ compiler to be installed on your system. Additionally, Nyxstone requires LLVM with 
+a major version in the range 15-18.
 
 ## Sample
 

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -7,7 +7,7 @@ Official bindings for the Nyxstone assembler/disassembler engine.
 
 ## Building
 
-The project can be build via `cargo build`, as long as LLVM 18 is installed in the `$PATH` or the environment variable `$NYXSTONE_LLVM_PREFIX` points to the installation location of a LLVM 18 library.
+The project can be build via `cargo build`, as long as LLVM (with at least version 15) is installed in the `$PATH` or the environment variable `$NYXSTONE_LLVM_PREFIX` points to the installation location of a LLVM library.
 
 LLVM might be linked against FFI, but not correctly report this fact via `llvm-config`. If your LLVM does link FFI and
 Nyxstone fails to run, set the `NYXSTONE_LINK_FFI` environment variable to some value, which will ensure that Nyxstone

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -46,7 +46,7 @@ fn main() {
     // === The following code is adapted from llvm-sys, see below for licensing ===
     let llvm_config_path = match search_llvm_config() {
         Ok(config) => config,
-        Err(e) => panic!("{e} Please either install LLVM 15 with static libs into your PATH or supply the location via $NYXSTONE_LLVM_PREFIX"),
+        Err(e) => panic!("{e} Please either install LLVM 18 with static libs into your PATH or supply the location via $NYXSTONE_LLVM_PREFIX"),
     };
 
     // Tell cargo about the library directory of llvm.
@@ -129,8 +129,8 @@ fn search_llvm_config() -> Result<PathBuf> {
             continue;
         };
 
-        if version != "15" {
-            return Err(anyhow!("LLVM major version is {}, must be 15.", version));
+        if version != "18" {
+            return Err(anyhow!("LLVM major version is {}, must be 18.", version));
         }
 
         return Ok(llvm_config);
@@ -194,9 +194,9 @@ fn target_os_is(name: &str) -> bool {
 fn llvm_config_binary_names() -> impl Iterator<Item = String> {
     let base_names = [
         "llvm-config".into(),
-        format!("llvm-config-{}", 15),
-        format!("llvm-config{}", 15),
-        format!("llvm{}-config", 15),
+        format!("llvm-config-{}", 18),
+        format!("llvm-config{}", 18),
+        format!("llvm{}-config", 18),
     ];
 
     // On Windows, also search for llvm-config.exe

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,11 +1,11 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use std::env;
 use std::ffi::OsStr;
-use std::io;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
 
 const ENV_LLVM_PREFIX: &str = "NYXSTONE_LLVM_PREFIX";
+const ENV_FORCE_FFI_LINKING: &str = "NYXSTONE_LINK_FFI";
 
 fn main() {
     let headers = [
@@ -43,32 +43,54 @@ fn main() {
     // let out_dir = std::env::var("OUT_DIR").unwrap();
     // let cxxbridge_dir = out_dir + "/../../../../cxxbridge";
 
-    let config = search_llvm_config();
-    if config.is_err() {
-        panic!("{} Please either install LLVM 15 with static libs into your PATH or supply the location via $NYXSTONE_LLVM_PREFIX", config.unwrap_err());
+    // === The following code is adapted from llvm-sys, see below for licensing ===
+    let llvm_config_path = match search_llvm_config() {
+        Ok(config) => config,
+        Err(e) => panic!("{e} Please either install LLVM 15 with static libs into your PATH or supply the location via $NYXSTONE_LLVM_PREFIX"),
     };
-    let config = config.unwrap();
 
     // Tell cargo about the library directory of llvm.
-    let libdir = llvm_config(&config, ["--libdir"]);
-    println!("cargo:libdir={}", libdir);
+    let libdir = llvm_config(&llvm_config_path, ["--libdir"]);
+
+    // Export information to other crates
+    println!("cargo:config_path={}", llvm_config_path.display()); // will be DEP_LLVM_CONFIG_PATH
+    println!("cargo:libdir={}", libdir); // DEP_LLVM_LIBDIR
+
+    // Link LLVM libraries
     println!("cargo:rustc-link-search=native={}", libdir);
-    // Tell cargo about all llvm static libraries to link against.
-    let llvm_libs = get_link_libraries(&config);
-    for name in llvm_libs {
-        println!("cargo:rustc-link-lib=static={}", name);
+    for link_search_dir in get_system_library_dirs() {
+        println!("cargo:rustc-link-search=native={}", link_search_dir);
+    }
+    // We need to take note of what kind of libraries we linked to, so that
+    // we can link to the same kind of system libraries
+    let (kind, libs) = get_link_libraries(&llvm_config_path);
+    for name in libs {
+        println!("cargo:rustc-link-lib={}={}", kind.string(), name);
     }
 
-    // llvm-sys uses the target os to select if system libs should be statically or dynamically linked.
-    let system_linking = if target_os_is("musl") { "static" } else { "dylib" };
-
-    // Tell cargo about the system libraries needed by llvm.
-    for name in get_system_libraries(&config) {
-        println!("cargo:rustc-link-lib={}={}", system_linking, name);
+    // Link system libraries
+    // We get the system libraries based on the kind of LLVM libraries we link to, but we link to
+    // system libs based on the target environment.
+    let sys_lib_kind = LibraryKind::Dynamic;
+    for name in get_system_libraries(&llvm_config_path, kind) {
+        println!("cargo:rustc-link-lib={}={}", sys_lib_kind.string(), name);
     }
+
+    if target_env_is("msvc") && is_llvm_debug(&llvm_config_path) {
+        println!("cargo:rustc-link-lib=msvcrtd");
+    }
+
+    // Sometimes, llvm-config might not report that ffi is needed as a system library.
+    // There is no way to detect this, thus the user must notify us via the environment
+    // variable.
+    if env::var(ENV_FORCE_FFI_LINKING).is_ok() {
+        println!("cargo:rustc-link-lib=dylib=ffi");
+    }
+
+    // ====================================================
 
     // Get the include directory for the c++ code.
-    let llvm_include_dir = llvm_config(&config, ["--includedir"]);
+    let llvm_include_dir = llvm_config(&llvm_config_path, ["--includedir"]);
 
     // Import Nyxstone C++ lib
     cxx_build::bridge("src/lib.rs")
@@ -86,38 +108,51 @@ fn main() {
     }
 }
 
-/// Searches for LLVM in $NYXSTONE_LLVM_PREFIX/bin and in the path and ensures proper version and static
-/// linking support.
-///
+/// Searches for LLVM in $NYXSTONE_LLVM_PREFIX/bin and in the path and ensures proper version
 /// # Returns
 /// `Ok()` and PathBuf to llvm-config, `Err()` otherwise
 fn search_llvm_config() -> Result<PathBuf> {
     let prefix = env::var(ENV_LLVM_PREFIX)
-        .map(|p| PathBuf::from(p).join("bin"))
+        .and_then(|p| {
+            if p.is_empty() {
+                return Err(std::env::VarError::NotPresent);
+            }
+
+            Ok(PathBuf::from(p).join("bin"))
+        })
         .unwrap_or_else(|_| PathBuf::new());
 
-    let llvm_config = Path::new(&prefix).join("llvm-config");
-    let version = get_major_version(&llvm_config).map_err(|_| {
-        anyhow!(
-            "No llvm-config found in {}",
-            if prefix == PathBuf::new() {
-                "$PATH"
-            } else {
-                "$NYXSTONE_LLVM_PREFIX"
-            }
-        )
-    })?;
-    let can_link = can_link_static(&llvm_config);
+    for name in llvm_config_binary_names() {
+        let llvm_config = Path::new(&prefix).join(name);
 
-    if version != "15" {
-        return Err(anyhow!("LLVM major version is {}, must be 15.", version));
+        let Ok(version) = get_major_version(&llvm_config) else {
+            continue;
+        };
+
+        if version != "15" {
+            return Err(anyhow!("LLVM major version is {}, must be 15.", version));
+        }
+
+        return Ok(llvm_config);
     }
 
-    if !can_link {
-        return Err(anyhow!("LLVM install does not include static libraries.",));
-    }
+    Err(anyhow!(
+        "No llvm-config found in {}",
+        if prefix == PathBuf::new() {
+            "$PATH"
+        } else {
+            "$NYXSTONE_LLVM_PREFIX"
+        }
+    ))
+}
 
-    Ok(llvm_config)
+fn get_major_version(binary: &Path) -> Result<String> {
+    Ok(llvm_config_ex(binary, ["--version"])
+        .context("Extracting LLVM major version")?
+        .split('.')
+        .next()
+        .expect("Unexpected llvm-config output.")
+        .to_owned())
 }
 
 // All following functions taken from llvm-sys crate and are licensed according to the following
@@ -141,47 +176,6 @@ fn search_llvm_config() -> Result<PathBuf> {
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-fn llvm_config_ex<I, S>(binary: &Path, args: I) -> anyhow::Result<String>
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<OsStr>,
-{
-    Ok(Command::new(binary)
-        .args(args)
-        .arg("--link-static") // Don't use dylib for >= 3.9
-        .output()
-        .and_then(|output| {
-            if output.stdout.is_empty() {
-                Err(io::Error::new(
-                    io::ErrorKind::NotFound,
-                    "llvm-config returned empty output",
-                ))
-            } else {
-                Ok(String::from_utf8(output.stdout).expect("Output from llvm-config was not valid UTF-8"))
-            }
-        })?)
-}
-
-fn llvm_config<I, S>(binary: &Path, args: I) -> String
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<OsStr>,
-{
-    llvm_config_ex(binary, args).expect("Surprising failure from llvm-config")
-}
-
-fn get_major_version(binary: &Path) -> Result<String> {
-    Ok(llvm_config_ex(binary, ["--version"])?
-        .split('.')
-        .next()
-        .ok_or(anyhow!("Unexpected llvm output"))?
-        .to_owned())
-}
-
-fn can_link_static(binary: &Path) -> bool {
-    llvm_config_ex(binary, ["--libs", "core", "mc", "all-targets"]).is_ok()
-}
-
 fn target_env_is(name: &str) -> bool {
     match env::var_os("CARGO_CFG_TARGET_ENV") {
         Some(s) => s == name,
@@ -196,38 +190,71 @@ fn target_os_is(name: &str) -> bool {
     }
 }
 
-fn target_dylib_extension() -> &'static str {
-    if target_os_is("macos") {
-        ".dylib"
+/// Return an iterator over possible names for the llvm-config binary.
+fn llvm_config_binary_names() -> impl Iterator<Item = String> {
+    let base_names = [
+        "llvm-config".into(),
+        format!("llvm-config-{}", 15),
+        format!("llvm-config{}", 15),
+        format!("llvm{}-config", 15),
+    ];
+
+    // On Windows, also search for llvm-config.exe
+    if target_os_is("windows") {
+        IntoIterator::into_iter(base_names)
+            .flat_map(|name| [format!("{}.exe", name), name])
+            .collect::<Vec<_>>()
     } else {
-        ".so"
+        base_names.to_vec()
     }
+    .into_iter()
 }
 
-fn get_system_libcpp() -> Option<&'static str> {
-    if target_env_is("msvc") {
-        // MSVC doesn't need an explicit one.
-        None
-    } else if target_os_is("macos") || target_os_is("freebsd") || target_env_is("musl") {
-        // On OS X 10.9 and later, LLVM's libc++ is the default. On earlier
-        // releases GCC's libstdc++ is default. Unfortunately we can't
-        // reasonably detect which one we need (on older ones libc++ is
-        // available and can be selected with -stdlib=lib++), so assume the
-        // latest, at the cost of breaking the build on older OS releases
-        // when LLVM was built against libstdc++.
-        Some("c++")
-    } else {
-        // Otherwise assume GCC's libstdc++.
-        // This assumption is probably wrong on some platforms, but would need
-        // testing on them.
-        Some("stdc++")
-    }
+/// Invoke the specified binary as llvm-config.
+fn llvm_config<I, S>(binary: &Path, args: I) -> String
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    llvm_config_ex(binary, args).expect("Surprising failure from llvm-config")
+}
+
+/// Invoke the specified binary as llvm-config.
+///
+/// Explicit version of the `llvm_config` function that bubbles errors
+/// up.
+fn llvm_config_ex<I, S>(binary: &Path, args: I) -> anyhow::Result<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut cmd = Command::new(binary);
+    (|| {
+        let Output { status, stdout, stderr } = cmd.args(args).output()?;
+        let stdout = String::from_utf8(stdout).context("stdout")?;
+        let stderr = String::from_utf8(stderr).context("stderr")?;
+        if status.success() {
+            Ok(stdout)
+        } else {
+            Err(anyhow::anyhow!(
+                "status={status}\nstdout={}\nstderr={}",
+                stdout.trim(),
+                stderr.trim()
+            ))
+        }
+    })()
+    .with_context(|| format!("{cmd:?}"))
 }
 
 /// Get the names of the dylibs required by LLVM, including the C++ standard
 /// library.
-fn get_system_libraries(llvm_config_path: &Path) -> Vec<String> {
-    llvm_config(llvm_config_path, ["--system-libs"])
+fn get_system_libraries(llvm_config_path: &Path, kind: LibraryKind) -> Vec<String> {
+    let link_arg = match kind {
+        LibraryKind::Static => "--link-static",
+        LibraryKind::Dynamic => "--link-shared",
+    };
+
+    llvm_config(llvm_config_path, ["--system-libs", link_arg])
         .split(&[' ', '\n'] as &[char])
         .filter(|s| !s.is_empty())
         .map(|flag| {
@@ -246,6 +273,13 @@ fn get_system_libraries(llvm_config_path: &Path) -> Vec<String> {
                         if let Some(flag) = flag.strip_prefix("lib").and_then(|flag| flag.strip_suffix(".tbd")) {
                             return flag;
                         }
+                    }
+
+                    if let Some(i) = flag.find(".so.") {
+                        // On some distributions (OpenBSD, perhaps others), we get sonames
+                        // like "-lz.so.7.0". Correct those by pruning the file extension
+                        // and library version.
+                        return &flag[..i];
                     }
                     return flag;
                 }
@@ -279,39 +313,152 @@ fn get_system_libraries(llvm_config_path: &Path) -> Vec<String> {
         .collect()
 }
 
-fn get_link_libraries(llvm_config_path: &Path) -> Vec<String> {
+/// Return additional linker search paths that should be used but that are not discovered
+/// by other means.
+///
+/// In particular, this should include only directories that are known from platform-specific
+/// knowledge that aren't otherwise discovered from either `llvm-config` or a linked library
+/// that includes an absolute path.
+fn get_system_library_dirs() -> impl IntoIterator<Item = &'static str> {
+    if target_os_is("openbsd") {
+        Some("/usr/local/lib")
+    } else {
+        None
+    }
+}
+
+fn target_dylib_extension() -> &'static str {
+    if target_os_is("macos") {
+        ".dylib"
+    } else {
+        ".so"
+    }
+}
+
+/// Get the library that must be linked for C++, if any.
+fn get_system_libcpp() -> Option<&'static str> {
+    if target_env_is("msvc") {
+        // MSVC doesn't need an explicit one.
+        None
+    } else if target_os_is("macos") {
+        // On OS X 10.9 and later, LLVM's libc++ is the default. On earlier
+        // releases GCC's libstdc++ is default. Unfortunately we can't
+        // reasonably detect which one we need (on older ones libc++ is
+        // available and can be selected with -stdlib=lib++), so assume the
+        // latest, at the cost of breaking the build on older OS releases
+        // when LLVM was built against libstdc++.
+        Some("c++")
+    } else if target_os_is("freebsd") || target_os_is("openbsd") {
+        Some("c++")
+    } else if target_env_is("musl") {
+        // The one built with musl.
+        Some("c++")
+    } else {
+        // Otherwise assume GCC's libstdc++.
+        // This assumption is probably wrong on some platforms, but would need
+        // testing on them.
+        Some("stdc++")
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LibraryKind {
+    Static,
+    Dynamic,
+}
+
+impl LibraryKind {
+    pub fn string(&self) -> &'static str {
+        match self {
+            LibraryKind::Static => "static",
+            LibraryKind::Dynamic => "dylib",
+        }
+    }
+}
+
+/// Get the names of libraries to link against, along with whether it is static or shared library.
+fn get_link_libraries(llvm_config_path: &Path) -> (LibraryKind, Vec<String>) {
     // Using --libnames in conjunction with --libdir is particularly important
     // for MSVC when LLVM is in a path with spaces, but it is generally less of
     // a hack than parsing linker flags output from --libs and --ldflags.
 
-    fn get_link_libraries_impl(llvm_config_path: &Path) -> String {
-        llvm_config(llvm_config_path, ["--libnames", "core", "mc", "all-targets"])
+    fn get_link_libraries_impl(llvm_config_path: &Path, kind: LibraryKind) -> anyhow::Result<String> {
+        // Windows targets don't get dynamic support.
+        // See: https://gitlab.com/taricorp/llvm-sys.rs/-/merge_requests/31#note_1306397918
+        if target_env_is("msvc") && kind == LibraryKind::Dynamic {
+            anyhow::bail!("Dynamic linking to LLVM is not supported on Windows");
+        }
+
+        let link_arg = match kind {
+            LibraryKind::Static => "--link-static",
+            LibraryKind::Dynamic => "--link-shared",
+        };
+        llvm_config_ex(llvm_config_path, ["--libnames", link_arg])
     }
 
-    extract_library(&get_link_libraries_impl(llvm_config_path))
+    // Prefer static linking
+    let preferences = [LibraryKind::Static, LibraryKind::Dynamic];
+
+    for kind in preferences {
+        match get_link_libraries_impl(llvm_config_path, kind) {
+            Ok(s) => return (kind, extract_library(&s, kind)),
+            Err(err) => {
+                println!("failed to get {} libraries from llvm-config: {err:?}", kind.string())
+            }
+        }
+    }
+
+    panic!("failed to get linking libraries from llvm-config",);
 }
 
-fn extract_library(s: &str) -> Vec<String> {
+fn extract_library(s: &str, kind: LibraryKind) -> Vec<String> {
     s.split(&[' ', '\n'] as &[char])
         .filter(|s| !s.is_empty())
         .map(|name| {
-            {
-                // --libnames gives library filenames. Extract only the name that
-                // we need to pass to the linker.
-                // Match static library
-                if let Some(name) = name.strip_prefix("lib").and_then(|name| name.strip_suffix(".a")) {
-                    // Unix (Linux/Mac)
-                    // libLLVMfoo.a
-                    name
-                } else if let Some(name) = name.strip_suffix(".lib") {
-                    // Windows
-                    // LLVMfoo.lib
-                    name
-                } else {
-                    panic!("'{}' does not look like a static library name", name)
+            // --libnames gives library filenames. Extract only the name that
+            // we need to pass to the linker.
+            match kind {
+                LibraryKind::Static => {
+                    // Match static library
+                    if let Some(name) = name.strip_prefix("lib").and_then(|name| name.strip_suffix(".a")) {
+                        // Unix (Linux/Mac)
+                        // libLLVMfoo.a
+                        name
+                    } else if let Some(name) = name.strip_suffix(".lib") {
+                        // Windows
+                        // LLVMfoo.lib
+                        name
+                    } else {
+                        panic!("'{}' does not look like a static library name", name)
+                    }
+                }
+                LibraryKind::Dynamic => {
+                    // Match shared library
+                    if let Some(name) = name.strip_prefix("lib").and_then(|name| name.strip_suffix(".dylib")) {
+                        // Mac
+                        // libLLVMfoo.dylib
+                        name
+                    } else if let Some(name) = name.strip_prefix("lib").and_then(|name| name.strip_suffix(".so")) {
+                        // Linux
+                        // libLLVMfoo.so
+                        name
+                    } else if let Some(name) =
+                        IntoIterator::into_iter([".dll", ".lib"]).find_map(|suffix| name.strip_suffix(suffix))
+                    {
+                        // Windows
+                        // LLVMfoo.{dll,lib}
+                        name
+                    } else {
+                        panic!("'{}' does not look like a shared library name", name)
+                    }
                 }
             }
             .to_string()
         })
         .collect::<Vec<String>>()
+}
+
+fn is_llvm_debug(llvm_config_path: &Path) -> bool {
+    // Has to be either Debug or Release
+    llvm_config(llvm_config_path, ["--build-mode"]).contains("Debug")
 }

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -46,7 +46,7 @@ fn main() {
     // === The following code is adapted from llvm-sys, see below for licensing ===
     let llvm_config_path = match search_llvm_config() {
         Ok(config) => config,
-        Err(e) => panic!("{e} Please either install LLVM 18 with static libs into your PATH or supply the location via $NYXSTONE_LLVM_PREFIX"),
+        Err(e) => panic!("{e} Please either install LLVM version >= 15 into your PATH or supply the location via $NYXSTONE_LLVM_PREFIX"),
     };
 
     // Tell cargo about the library directory of llvm.
@@ -129,7 +129,9 @@ fn search_llvm_config() -> Result<PathBuf> {
             continue;
         };
 
-        if version != "18" {
+        let version = version.parse::<u32>().context("Parsing LLVM version")?;
+
+        if version < 15 {
             return Err(anyhow!("LLVM major version is {}, must be 18.", version));
         }
 

--- a/cmake/FindLLVM-Wrapper.cmake
+++ b/cmake/FindLLVM-Wrapper.cmake
@@ -23,9 +23,20 @@ if(LLVM-Wrapper_FIND_REQUIRED)
     list(APPEND FIND_ARGS "REQUIRED")
 endif()
 
+set(ALLOWED_LLVM_VERSIONS 15 16 17 18.0 18.1)
+
 # Find LLVM
-find_package(LLVM ${FIND_ARGS})
+foreach(VERSION ${ALLOWED_LLVM_VERSIONS})
+    find_package(LLVM ${VERSION} QUIET ${FIND_ARGS})
+    if(${LLVM_FOUND})
+        break()
+    endif()
+endforeach()
 unset(FIND_ARGS)
+
+if(NOT ${LLVM_FOUND})
+    message(FATAL_ERROR "Did not find LLVM that has a compatible version. Allowed versions are 15-18.")
+endif()
 
 if(NOT LLVM-Wrapper_FIND_QUIETLY)
     message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")


### PR DESCRIPTION
Uses more of llvm-sys build.rs to support dynamic linking when static linking is not supported. Additionally, adds the `NYXSTONE_LINK_FFI` flag, which tells nyxstone that `libffi` should be linked. This is necessary as LLVM sometimes might be linked against `libffi` but not report this fact via `llvm-config`. 

Furthermore adds changes to the python `setup.py` to support dynamic linking in python, when static linking is not supported.