### PR TITLE
Update the README to match recent changes

### DIFF
--- a/cmake/FindLLVM-Wrapper.cmake
+++ b/cmake/FindLLVM-Wrapper.cmake
@@ -42,7 +42,7 @@ elseif(LLVM-Wrapper_FIND_COMPONENTS)
     if(NOT LLVM-Wrapper_FIND_QUIETLY)
         message(STATUS "LLVM components: ${LLVM-Wrapper_FIND_COMPONENTS}")
     endif()
-    llvm_map_components_to_libnames(LLVM-Wrapper_LIBS ${LLVM-Wrapper_FIND_COMPONENTS}) 
+    llvm_map_components_to_libnames(LLVM-Wrapper_LIBS ${LLVM-Wrapper_FIND_COMPONENTS})
 else()
     set(LLVM-Wrapper_LIBS ${LLVM_AVAILABLE_LIBS})
 endif()
@@ -59,6 +59,18 @@ add_library(LLVM-Wrapper INTERFACE IMPORTED)
 target_include_directories(LLVM-Wrapper SYSTEM INTERFACE ${LLVM_INCLUDE_DIRS})
 target_link_libraries(LLVM-Wrapper INTERFACE ${LLVM-Wrapper_LIBS})
 target_compile_definitions(LLVM-Wrapper INTERFACE ${LLVM_DEFINITIONS})
+
+# Set the appropriate minimum C++ standard
+if(LLVM_VERSION VERSION_GREATER_EQUAL "16.0.0")
+    # https://releases.llvm.org/16.0.0/docs/CodingStandards.html#c-standard-versions
+    target_compile_features(LLVM-Wrapper INTERFACE cxx_std_17)
+elseif(LLVM_VERSION VERSION_GREATER_EQUAL "10.0.0")
+    # https://releases.llvm.org/10.0.0/docs/CodingStandards.html#c-standard-versions
+    target_compile_features(LLVM-Wrapper INTERFACE cxx_std_14)
+else()
+    # https://releases.llvm.org/9.0.0/docs/CodingStandards.html#c-standard-versions
+    target_compile_features(LLVM-Wrapper INTERFACE cxx_std_11)
+endif()
 
 if(WIN32)
     target_compile_definitions(LLVM-Wrapper INTERFACE NOMINMAX)


### PR DESCRIPTION
- Update LLVM compilation instructions to work on Windows
- The `LLVM-Wrapper` abstracts away different LLVM configurations, so dynamic linking will work.
- I updated the CMake in #59 to use transitive target properties, so everything will work when doing `target_link_libraries(example PRIVATE nyxstone::nyxstone)` (the dependency on LLVM is transitively resolved). This is generally how 'modern CMake' has worked in the past ~5 years and it simplifies things a lot.
  - When I have more time I will also add proper installation support to `nyxstone`, then people can replace `add_subdirectory` with `find_package(nyxstone)` and the same instructions will keep working.
- I forgot to push a minor change to the `LLVM-Wrapper` (C++ standard requirement), this is not necessary for things to work but helpful in case people copy the file.