### PR TITLE
Add recommended triples to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,14 +108,22 @@ Then, `nyxstone` can be used from the command line. Here's an output of its help
 $ ./nyxstone --help
 Allowed options:
   --help                    Show this message
-  --arch arg (=x86_64)      LLVM triple or architecture identifier of triple,
-                            for example "x86_64", "x86_64-linux-gnu", "armv8",
-                            "armv8eb", "thumbv8", "aarch64"
-  --cpu arg                 LLVM cpu specifier, refer to `llc -march=ARCH
+  --arch arg (=x86_64)      LLVM triple or architecture identifier of triple.
+                            For the most common architectures, we recommend:
+                            x86_32: `i686-linux-gnu`
+                            x86_64: `x86_64-linux-gnu`
+                            armv6m: `armv6m-none-eabi`
+                            armv7m: `armv7m-none-eabi`
+                            armv8m: `armv8m.main-none-eabi`
+                            aarch64: `aarch64-linux-gnueabihf`
+                            Using shorthand identifiers like `arm` can lead to
+                            Nyxstone not being able to assemble certain
+                            instructions.
+  --cpu arg                 LLVM cpu specifier, refer to `llc -mtriple=ARCH
                             -mcpu=help` for a comprehensive list
   --features arg            LLVM features to enable/disable, comma seperated
-                            feature strings prepended by '+' or '-' toenable or
-                            disable respectively. Refer to `llc -march=ARCH
+                            feature strings prepended by '+' or '-' to enable or
+                            disable respectively. Refer to `llc -mtriple=ARCH
                             -mattr=help` for a comprehensive list
   --address arg (=0)        Address
 

--- a/bindings/rust/examples/cli.rs
+++ b/bindings/rust/examples/cli.rs
@@ -28,8 +28,21 @@ enum Command {
 /// Rust CLI for Nyxstone
 #[derive(Parser)]
 struct Args {
-    /// Architecture LLVM triple or architecture identifier of triple, for example "x86_64", "x86_64-linux-gnu",
-    /// "armv8", "armv8eb", "thumbv8", "aarch64"
+    /// LLVM triple or architecture identifier of triple. For the most common architectures, we recommend:
+    ///
+    /// - x86_32: `i686-linux-gnu`
+    ///
+    /// - x86_64: `x86_64-linux-gnu`
+    ///
+    /// - armv6m: `armv6m-none-eabi`
+    ///
+    /// - armv7m: `armv7m-none-eabi`
+    ///
+    /// - armv8m: `armv8m.main-none-eabi`
+    ///
+    /// - aarch64: `aarch64-linux-gnueabihf`
+    ///
+    /// Using shorthand identifiers like `arm` can lead to Nyxstone not being able to assemble certain instructions.
     #[arg(short = 'a', long)]
     architecture: String,
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -76,6 +76,16 @@ impl Nyxstone {
     /// - `target_triple`: Llvm target triple or architecture identifier of triple.
     /// - `config`: Optional configuration for the `Nyxstone` instance.
     ///
+    /// # Note
+    ///  For the most common architectures, we recommend the following triples:
+    ///  - x86_32: `i686-linux-gnu`
+    ///  - x86_64: `x86_64-linux-gnu`
+    ///  - armv6m: `armv6m-none-eabi`
+    ///  - armv7m: `armv7m-none-eabi`
+    ///  - armv8m: `armv8m.main-none-eabi`
+    ///  - aarch64: `aarch64-linux-gnueabihf`
+    ///  Using shorthand identifiers like `arm` can lead to Nyxstone not being able to assemble certain instructions.
+    ///
     /// # Returns
     /// Ok() and the Nyxstone instance on success, Err() otherwise.
     ///

--- a/examples/nyxstone-cli.cpp
+++ b/examples/nyxstone-cli.cpp
@@ -26,12 +26,19 @@ int main(int argc, char** argv)
     desc.add_options()
         ("help", "Show this message")
         ("arch", po::value<std::string>()->default_value("x86_64"),
-            "LLVM triple or architecture identifier of triple, for example "
-            R"("x86_64", "x86_64-linux-gnu", "armv8", "armv8eb", "thumbv8", "aarch64")")
+            "LLVM triple or architecture identifier of triple. For the most common architectures, we recommend:\n"
+            "x86_32: `i686-linux-gnu`\n"
+            "x86_64: `x86_64-linux-gnu`\n"
+            "armv6m: `armv6m-none-eabi`\n"
+            "armv7m: `armv7m-none-eabi`\n"
+            "armv8m: `armv8m.main-none-eabi`\n"
+            "aarch64: `aarch64-linux-gnueabihf`\n"
+            "Using shorthand identifiers like `arm` can lead to Nyxstone not being able to assemble certain instructions."
+        )
         ("cpu", po::value<std::string>()->default_value(""),
             "LLVM cpu specifier, refer to `llc -mtriple=ARCH -mcpu=help` for a comprehensive list")
         ("features", po::value<std::string>()->default_value(""),
-            "LLVM features to enable/disable, comma seperated feature strings prepended by '+' or '-' to"
+            "LLVM features to enable/disable, comma seperated feature strings prepended by '+' or '-' to "
             "enable or disable respectively. Refer to `llc -mtriple=ARCH -mattr=help` for a comprehensive list")
         ("address", po::value<std::string>()->default_value("0"), "Address")
     ;

--- a/include/nyxstone.h
+++ b/include/nyxstone.h
@@ -156,6 +156,16 @@ public:
 
     /// @brief Creates a NyxstoneBuilder instance.
     /// @param triple Llvm target triple or architecture identifier of a triple.
+    ///
+    /// @note For the most common architectures, we recommend:
+    ///       x86_32: `i686-linux-gnu`
+    ///       x86_64: `x86_64-linux-gnu`
+    ///       armv6m: `armv6m-none-eabi`
+    ///       armv7m: `armv7m-none-eabi`
+    ///       armv8m: `armv8m.main-none-eabi`
+    ///       aarch64: `aarch64-linux-gnueabihf`
+    ///       Using shorthand identifiers like `arm` can lead to Nyxstone not being able to assemble certain
+    ///       instructions.
     explicit NyxstoneBuilder(std::string&& triple)
         : m_triple(std::move(triple)) {};
     NyxstoneBuilder(const NyxstoneBuilder&) = default;


### PR DESCRIPTION
Currently, we do not provide any examples for triples and use shorthand triples in all examples. This gives way to the assumption that all triples (and their shorthands) are created equal, when in reality they are not (see #63 for reference).

This commit documents common triples we use internally and makes it clearer that triple shorthands can decrease Nyxstones ability to asseble certain instructions.

Fixes #64.