### PR TITLE
Initial changes for LLVM 18 compatibility on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(DEFINED $ENV{NYXSTONE_LLVM_PREFIX})
     set(CMAKE_PREFIX_PATH $ENV{NYXSTONE_LLVM_PREFIX})
 endif()
 
-find_package(LLVM-Wrapper 15 REQUIRED COMPONENTS
+find_package(LLVM-Wrapper REQUIRED COMPONENTS
     core
     mc
     AllTargetsCodeGens

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -29,12 +29,6 @@ class ValidLLVMConfig:
 
         major_version = version.split(".")[0]
 
-        if major_version != "15":
-            print(
-                f"LLVM Major version must be 15, found {major_version}! Try setting the env variable ${LLVM_PREFIX_NAME} to tell nyxstone about the install location of LLVM 15."
-            )
-            exit(1)
-
         lib_output = subprocess.run(
             [
                 llvm_config,
@@ -77,6 +71,7 @@ class ValidLLVMConfig:
         lib_location = (
             subprocess.run([self.config, "--ldflags"], capture_output=True)
             .stdout.decode("utf-8")
+            .split(" ")[0]
             .replace("\n", "")  # remove trailing '\n'
             .replace("-L", "")  # remove leading -L re-added by pybind
             .strip()  # strip trailing whitespace
@@ -114,10 +109,7 @@ ext_modules = [
         include_dirs=["nyxstone-cpp/include/", "nyxstone-cpp/src/", llvm_inc_dir],
         libraries=llvm_libs,
         library_dirs=[llvm_lib_dir],
-        extra_link_args=[
-            "-static-libstdc++",
-            "-static-libgcc",
-        ],  # try to reduce dependencies
+        extra_link_args=[],
     )
 ]
 


### PR DESCRIPTION
I've made some minimal changes to get Nyxstone to build with LLVM 18 on macOS:

- Adjusted `find_package` call to not specify the LLVM version. I think it's probably best to not force a specific LLVM version considering a new major release of LLVM is available roughly every 6 months.
- Removed a similar version check from the Python bindings build script.
- Pruned the results of `llvm-config --ldflags`, which returns multiple flags on my system, only the first of which is the needed '-L' flag.
- Removed link arguments that are unknown on macOS.

Notable TODOs include:

- Updating Rust bindings build script.
- Probably other stuff?

If these changes look good and support for LLVM 18 is desired, I can go ahead and clean these up and test on other platforms; otherwise, I'll just use my fork for now.