### PR TITLE
Fix MSVC C++ standard flag in Rust bindings

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -72,7 +72,7 @@ fn main() {
 
     // Import Nyxstone C++ lib
     cxx_build::bridge("src/lib.rs")
-        .flag_if_supported("-std=c++17")
+        .std("c++17")
         .include("nyxstone/include")
         .include(llvm_include_dir.trim())
         // .include(cxxbridge_dir)

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -84,7 +84,7 @@ impl Nyxstone {
     ///  - armv7m: `armv7m-none-eabi`
     ///  - armv8m: `armv8m.main-none-eabi`
     ///  - aarch64: `aarch64-linux-gnueabihf`
-    ///  Using shorthand identifiers like `arm` can lead to Nyxstone not being able to assemble certain instructions.
+    ///    Using shorthand identifiers like `arm` can lead to Nyxstone not being able to assemble certain instructions.
     ///
     /// # Returns
     /// Ok() and the Nyxstone instance on success, Err() otherwise.


### PR DESCRIPTION
MSVC requires `/std:c++17` rather than `-std=c++17`.
Updated cxx_build configuration to use `.std("c++17")` to make nyxstone Rust bindings build correctly on Windows.