### PR TITLE
Change CI to push to cpp-docs branch

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,4 +1,4 @@
-name: update-docs
+name: docs
 
 on:
   push:
@@ -32,8 +32,6 @@ jobs:
         CI_COMMIT_AUTHOR: update-docs-ci
       # only commit and push changes on the main branch after the mr has been pushed.
       if: github.event_name == 'push'
-      # Force-adds the docs directory, because the docs directory is still in .gitignore
-      # to discourage changing the docs directory in a commit.
       run: |
         git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
         git config --global user.email "emproof-com@users.noreply.github.com"

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -37,7 +37,8 @@ jobs:
       run: |
         git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
         git config --global user.email "emproof-com@users.noreply.github.com"
-        git add -f  docs
+        git checkout cpp-docs
+        git add doc
         git commit -m "${{ env.CI_COMMIT_MESSAGE }}"
         git push
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -2,5 +2,5 @@ PROJECT_NAME = Nyxstone
 HTML_OUTPUT = ./docs/
 GENERATE_HTML = YES
 GENERATE_LATEX = NO
-INPUT = src include README.md include/tl
+INPUT = src include README.md vendor
 USE_MDFILE_AS_MAINPAGE = README.md

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Github Cpp CI Badge](https://github.com/emproof-com/nyxstone/actions/workflows/cpp.yml/badge.svg)](https://github.com/emproof-com/nyxstone/actions/workflows/cpp.yml)
 [![crates.io](https://img.shields.io/crates/v/nyxstone.svg)](https://crates.io/crates/nyxstone)
 [![PyPI](https://img.shields.io/pypi/v/nyxstone.svg)](https://pypi.org/project/nyxstone)
+[![cpp-docs](https://github.com/emproof-com/nyxstone/actions/workflows/doxygen.yml/badge.svg)](https://emproof-com.github.io/nyxstone/)
 
 Nyxstone is a powerful assembly and disassembly library based on LLVM. It doesn’t require patches to the LLVM source tree and links against standard LLVM libraries available in most Linux distributions. Implemented as a C++ library, Nyxstone also offers Rust and Python bindings. It supports all official LLVM architectures and allows to configure architecture-specific target settings.
 


### PR DESCRIPTION
Previously, our CI job pushed doc changes to the master branch. But since we do not allow direct changes to master the job always failed. This MR changes the CI job to push the changes to the `cpp-docs` branch instead, from which we now deploy the c++ documentation.