### PR TITLE
Do not emit UnusedParameter warnings for LLVM code

### DIFF
--- a/include/nyxstone.h
+++ b/include/nyxstone.h
@@ -2,12 +2,15 @@
 
 #include <expected.hpp>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <llvm/MC/MCAsmInfo.h>
 #include <llvm/MC/MCInstPrinter.h>
 #include <llvm/MC/MCInstrInfo.h>
 #include <llvm/MC/MCRegisterInfo.h>
 #include <llvm/MC/MCSubtargetInfo.h>
 #include <llvm/MC/TargetRegistry.h>
+#pragma GCC diagnostic pop
 
 namespace nyxstone {
 

--- a/src/ELFStreamerWrapper.cpp
+++ b/src/ELFStreamerWrapper.cpp
@@ -4,6 +4,8 @@
 
 #include <llvm/MC/MCELFStreamer.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <llvm/MC/MCAsmBackend.h>
 #include <llvm/MC/MCAsmLayout.h>
 #include <llvm/MC/MCAssembler.h>
@@ -18,6 +20,7 @@
 #include <llvm/MC/MCSymbol.h>
 #include <llvm/MC/MCValue.h>
 #include <llvm/Support/Casting.h>
+#pragma GCC diagnostic pop
 
 #include <numeric>
 #include <sstream>

--- a/src/ELFStreamerWrapper.h
+++ b/src/ELFStreamerWrapper.h
@@ -2,10 +2,13 @@
 
 #include "nyxstone.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <llvm/MC/MCAsmBackend.h>
 #include <llvm/MC/MCCodeEmitter.h>
 #include <llvm/MC/MCELFStreamer.h>
 #include <llvm/MC/MCObjectWriter.h>
+#pragma GCC diagnostic pop
 
 namespace nyxstone {
 /// This class derives from LLVM's MCELFStreamer, which enables us to receive

--- a/src/ObjectWriterWrapper.h
+++ b/src/ObjectWriterWrapper.h
@@ -4,6 +4,8 @@
 
 #include <llvm/Config/llvm-config.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <llvm/MC/MCAsmBackend.h>
 #include <llvm/MC/MCAsmLayout.h>
 #include <llvm/MC/MCAssembler.h>
@@ -16,6 +18,7 @@
 #include <llvm/MC/MCSection.h>
 #include <llvm/MC/MCSymbol.h>
 #include <llvm/MC/MCValue.h>
+#pragma GCC diagnostic pop
 
 namespace nyxstone {
 /// This class enables us to limit the final output byte stream to the

--- a/src/nyxstone.cpp
+++ b/src/nyxstone.cpp
@@ -3,6 +3,8 @@
 #include "ELFStreamerWrapper.h"
 #include "ObjectWriterWrapper.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <llvm/MC/MCAsmBackend.h>
 #include <llvm/MC/MCCodeEmitter.h>
 #include <llvm/MC/MCDisassembler/MCDisassembler.h>
@@ -14,6 +16,7 @@
 #include <llvm/MC/TargetRegistry.h>
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/TargetSelect.h>
+#pragma GCC diagnostic pop
 
 #include <mutex>
 #include <numeric>


### PR DESCRIPTION
This PR ensures that the unused parameters from the LLVM code are ignored (especially for the rust build).