### PR TITLE
Prepare python/rust releases

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -123,7 +123,7 @@ ext_modules = [
 
 setup(
     name="nyxstone",
-    version="0.1.0",
+    version="0.1.1",
     description=desc,
     author="emproof B.V.",
     author_email="oss@emproof.com",

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -16,7 +16,6 @@ keywords = ["assembly", "disassembly", "arm", "x86_64", "reverse-engineering"]
 description = "Bindings for the nyxstone assembler/disassembler"
 categories = ["api-bindings", "compilers"]
 license = "MIT"
-license-file = "LICENSE"
 
 [dependencies]
 anyhow = { version = "1.0.68", default-features = true }

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyxstone"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["emproof B.V. <oss@emproof.com>", "Philipp Koppe <pkoppe@emproof.com>", "Rachid Mzannar <rmzannar@emproof.com>", "Darius Hartlief <dhartlief@emproof.com>"]
 edition = "2021"
 include = [


### PR DESCRIPTION
After these changes are merged, we should be able to release on both PyPI and crates.io.