### PR TITLE
Use compile_commands.json as base for clang-tidy

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -24,14 +24,14 @@ jobs:
       run: ./tool/format.sh check
     - name: Code quality - cppcheck
       run: ./tool/static-analysis-cppcheck.sh
-    - name: Code quality - clang-tidy
-      run: ./tool/static-analysis-tidy.sh
     - name: Build
       run: |
         mkdir build
         cd build
-        cmake ..
+        cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         make
+    - name: Code quality - clang-tidy
+      run: ./tool/static-analysis-tidy.sh
     - name: Test
       working-directory: build/
       run: make test

--- a/tool/static-analysis-tidy.sh
+++ b/tool/static-analysis-tidy.sh
@@ -11,37 +11,21 @@ fi
 
 # Since we cannot be sure from which directory we are called from, try to find 
 # nyxstone and cd into it.
+current_dir="$(pwd)"
 cd "$(git rev-parse --show-toplevel)"
 
 # Search all nyxstone cpp files but ignore the files copied from LLVM by only searching
 # to a depth of 2.
 cxx_files=$(find . -maxdepth 2 -iname "*.cpp" | xargs echo)
-# Include directories so that headers can be found.
-includes="-Iinclude -Ivendor"
-
-# Set standard to c++17.
-cxx_flags="-std=c++17"
-# Tell tidy to use libc++, as it is otherwise is unable to find any function the stdlib.
-cxx_flags+=" -stdlib=libc++"
-
-# Add flags needed for llvm.
-if [[ "$NYXSTONE_LLVM_PREFIX" != "" ]]; then
-    llvm="$NYXSTONE_LLVM_PREFIX/bin/llvm-config"
-else
-    llvm="llvm-config"
-fi
-cxx_flags+=" $("$llvm" --cppflags)"
 
 # We are currently not analyzing the ffi files, i.e. nyxstone_wrap
 # because there is no nice way to include the cxx.h file from the rustcxx
 # package. Ignoring it is not possible, since clang-tidy handles this as a
 # compiler error.
-# include ffi nyxstone_wrap header:
-# includes+=" -Isrc"
-# check nyxstone_wrap
-# cxx_files+=" ./src/nyxstone_wrap.cpp"
 
 # For some reason clang-tidy fails when the args string is given directly,
 # which is the reason for writing them to this variable first:
-clang_args="$cxx_files -- $cxx_flags $includes"
+clang_args="-p build $cxx_files"
 clang-tidy $clang_args
+
+cd $current_dir


### PR DESCRIPTION
In the `clang-tidy` script we were adding all arguments to clang-tidy by hand. Using the `-p` flag it will use the project build file to infer the correct build flags and includes.