### PR TITLE
Feature flags to configure linking (dynamic or static)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,10 +43,10 @@ jobs:
     - name: Packages
       run: brew install llvm@15
     - name: Build
-      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@15)" NYXSTONE_LINK_FFI=1 cargo build
+      run: NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@15)" NYXSTONE_LINK_FFI=1 cargo build
       working-directory: ${{ env.working-dir }}
     - name: Run tests
-      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" RUSTDOCFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@15)" NYXSTONE_LINK_FFI=1 cargo test
+      run: NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@15)" NYXSTONE_LINK_FFI=1 cargo test
       working-directory: ${{ env.working-dir }}
 
   mac-llvm-16:
@@ -58,10 +58,10 @@ jobs:
     - name: Packages
       run: brew install llvm@16
     - name: Build
-      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@16)" NYXSTONE_LINK_FFI=1 cargo build
+      run: NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@16)" NYXSTONE_LINK_FFI=1 cargo build
       working-directory: ${{ env.working-dir }}
     - name: Run tests
-      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" RUSTDOCFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@16)" NYXSTONE_LINK_FFI=1 cargo test
+      run: NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@16)" NYXSTONE_LINK_FFI=1 cargo test
       working-directory: ${{ env.working-dir }}
 
   mac-llvm-17:
@@ -73,10 +73,10 @@ jobs:
     - name: Packages
       run: brew install llvm@17
     - name: Build
-      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@17)" NYXSTONE_LINK_FFI=1 cargo build
+      run: NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@17)" NYXSTONE_LINK_FFI=1 cargo build
       working-directory: ${{ env.working-dir }}
     - name: Run tests
-      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" RUSTDOCFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@17)" NYXSTONE_LINK_FFI=1 cargo test
+      run: NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@17)" NYXSTONE_LINK_FFI=1 cargo test
       working-directory: ${{ env.working-dir }}
 
   mac-llvm-18:
@@ -88,9 +88,9 @@ jobs:
     - name: Packages
       run: brew install llvm@18
     - name: Build
-      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@18)" NYXSTONE_LINK_FFI=1 cargo build
+      run: NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@18)" NYXSTONE_LINK_FFI=1 cargo build
       working-directory: ${{ env.working-dir }}
     - name: Run tests
-      run: RUSTFLAGS="-L$(brew --prefix zstd)/lib" RUSTDOCFLAGS="-L$(brew --prefix zstd)/lib" NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@18)" NYXSTONE_LINK_FFI=1 cargo test
+      run: NYXSTONE_LLVM_PREFIX="$(brew --prefix llvm@18)" NYXSTONE_LINK_FFI=1 cargo test
       working-directory: ${{ env.working-dir }}
 

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -25,5 +25,18 @@ clap = { version = "4.5", features = ["derive"] }
 cxx-build = "1.0.94"
 anyhow = { version = "1.0.68", default-features = true }
 
+[features]
+# Linking preference.
+# If none of these is selected, it defaults to force static linking to match
+# the behaviour before this feature is introduced.
+# Prefer dynamic linking to LLVM library if possible.
+prefer-dynamic = []
+# Force dynamic linking.
+force-dynamic = []
+# Prefer static linking to LLVM library if possible.
+prefer-static = []
+# Force static linking
+force-static = []
+
 [lib]
 path = "src/lib.rs"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -414,8 +414,12 @@ impl LinkingPreferences {
             );
         }
 
-        // if no preference is given, default to prefer static linking
-        let prefer_static = prefer_static || !(prefer_dynamic || force_static || force_dynamic);
+        // if no preference is given, default to prefer static linking or dynamic linking for macOS
+        // targets
+        let prefer_static = match target_os_is("macos") {
+            true => false,
+            false => prefer_static || !(prefer_dynamic || force_static || force_dynamic),
+        };
 
         LinkingPreferences {
             prefer_static: force_static || prefer_static,


### PR DESCRIPTION
This PR adds rust feature flags which can be configured to prefer linking with dynamic or static libraries, or force link with dynamic / static libraries. This is especially useful for macOS targets which attempt to link statically against llvm. LLVM now requires libzstd which it cannot find by default under macOS, without having to specify LDFLAGS (or RUSTFLAGS). However, it seems that this can be circumvented by linking dynamically against LLVM (which is now the default for macOS).

